### PR TITLE
Feat/better toasts

### DIFF
--- a/packages/components/lib/utils/hooks/useWaitForTx.ts
+++ b/packages/components/lib/utils/hooks/useWaitForTx.ts
@@ -10,7 +10,7 @@ type WaitForTx = {
 
 const useWaitForTx = ({
   successMessage,
-  loadingMessage = "Sending...",
+  loadingMessage = "Working...",
   errorMessage,
   onSuccess,
   onError,
@@ -23,17 +23,16 @@ const useWaitForTx = ({
 
     const toastId = toast.loading(LOADING_MESSAGE, {
       position: "top-center",
-      duration: 7_000, // terminate after 1secs
     });
 
     (tx?.wait || Promise.resolve)()
       .then(() => {
-        toast.dismiss(toastId);
         if (SUCESS_MESSAGE) {
           toast.success(SUCESS_MESSAGE, {
             position: "top-center",
           });
         }
+        toast.dismiss(toastId);
         (overrides.onSuccess || onSuccess)?.(hash);
       })
       .catch(() => {

--- a/packages/components/lib/utils/hooks/useWaitForTx.ts
+++ b/packages/components/lib/utils/hooks/useWaitForTx.ts
@@ -10,7 +10,7 @@ type WaitForTx = {
 
 const useWaitForTx = ({
   successMessage,
-  loadingMessage = "Working...",
+  loadingMessage = "Loading...",
   errorMessage,
   onSuccess,
   onError,

--- a/packages/components/lib/utils/hooks/useWaitForTx.ts
+++ b/packages/components/lib/utils/hooks/useWaitForTx.ts
@@ -1,0 +1,52 @@
+import toast from "react-hot-toast";
+
+type WaitForTx = {
+  successMessage?: string;
+  errorMessage?: string;
+  loadingMessage?: string;
+  onSuccess?: (txHash: string) => void;
+  onError?: (txHash: string) => void;
+};
+
+const useWaitForTx = ({
+  successMessage,
+  loadingMessage = "Sending...",
+  errorMessage,
+  onSuccess,
+  onError,
+}: WaitForTx = {}) => {
+  const waitForTx = (tx: { hash: string; wait: () => Promise<any> }, overrides: WaitForTx = {}) => {
+    const { hash } = tx;
+    const LOADING_MESSAGE = overrides.loadingMessage || loadingMessage;
+    const ERROR_MESSAGE = overrides.errorMessage || errorMessage;
+    const SUCESS_MESSAGE = overrides.successMessage || successMessage;
+
+    const toastId = toast.loading(LOADING_MESSAGE, {
+      position: "top-center",
+      duration: 7_000, // terminate after 1secs
+    });
+
+    (tx?.wait || Promise.resolve)()
+      .then(() => {
+        toast.dismiss(toastId);
+        if (SUCESS_MESSAGE) {
+          toast.success(SUCESS_MESSAGE, {
+            position: "top-center",
+          });
+        }
+        (overrides.onSuccess || onSuccess)?.(hash);
+      })
+      .catch(() => {
+        if (ERROR_MESSAGE) {
+          toast.error(ERROR_MESSAGE, {
+            position: "top-center",
+          });
+        }
+        (overrides.onError || onError)?.(hash);
+      });
+  };
+
+  return { waitForTx };
+};
+
+export default useWaitForTx;

--- a/packages/utils/src/wagmi.ts
+++ b/packages/utils/src/wagmi.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from "react";
 
 export type UseContractReadReturn = ReturnType<typeof useContractRead>;
 
-export const REFETCH_TIME_IN_MS = 15_000;
+export const REFETCH_TIME_IN_MS = 8_000;
 export const MAX_RETRY_COUNT = 10;
 export const useConsistentRepolling = <T extends UseContractReadReturn = UseContractReadReturn>(wagmiReadCall: T) => {
   const [count, setCount] = useState(0);


### PR DESCRIPTION
wagmi on success returns a receipt where we can `wait` for confirmations to know if a tx was successful. This adds a hook to track success, error scenarios for such.

Note that wagmi's `onError` can be taken as a user-end error, _eg: Rejected Tx_.

## Reference


https://user-images.githubusercontent.com/26236985/228852947-d56aa280-be05-4b58-9bd8-9244695a8dba.mov

